### PR TITLE
Updating weather-api for python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 wikipedia
 SpeechRecognition
 pygame
-weather-api
+python3-weather-api
 pyowm
 pyaudio
 pyttsx3


### PR DESCRIPTION
The weather-api name has change in python3 to python3-weather-api.