### PR TITLE
Enable tox support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ cache: pip
 install:
   - sudo apt-get install portaudio19-dev
   - pip install -r requirements.txt
-  - pip install codecov
-  - pip install nose-cov
+  - pip install -r test-requirements.txt
   - python -c "import nltk; nltk.download('stopwords')"
 script:
   - nosetests --nocapture --with-cov --cov-config .coveragerc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[metadata]
+name = voice-enabled-chatbot
+summary = Voice enabled chat bot
+description-file =
+    README.md
+
+classifier =
+    Intended Audience :: Information Technology
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+
+[files]
+packages =
+    microbots

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['pbr>=1.8'],
+    pbr=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+codecov
+nose-cov
+pycodestyle

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+skipsdist = True
+envlist = py37,pep8
+
+[testenv]
+basepython = python3
+usedevelop = True
+install_command = pip install {opts} {packages}
+setenv =
+   VIRTUAL_ENV={envdir}
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+
+[testenv:pep8]
+commands = pycodestyle {posargs}
+
+[testenv:nosetests]
+commands = nosetests --nocapture --with-cov --cov-config .coveragerc
+
+[pycodestyle]
+# E123, E125 skipped as they are invalid PEP-8.
+show-source = True
+ignore = W504,E402,E731,C406,E741,E231,E501,
+         E222,W293,W391,W291,E265,E251,E303,E122,
+         E221,E703,E111,E101,W191,E117,E302,E262,
+         E261,E226
+max-line-length = 100
+exclude=.venv,.git,.tox,dist,doc,lib/python,*egg,build


### PR DESCRIPTION
This patch enable tox support on chatbot project.
Initially, it's skipping several pep8 otherwise it won't pass the CI.
Once the patch get merged, it's possible to start remove the ignored
peps.
This will allow tests to be executed locally, before the patch get
submited, and improve the code quality.
This also add the test-requirements.txt and change the travis yaml file
to use it, instead of the pip install commands.